### PR TITLE
Update README for Astro stack and switch to proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,21 @@
-MIT License
+All Rights Reserved
 
-Copyright (c) 2020 Glenn
+Copyright (c) 2026 Glenn Sheppard
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This source code and all associated files (the "Software") are the exclusive
+property of Glenn Sheppard and are provided publicly for viewing and reference
+purposes only.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+No permission is granted to any person to use, copy, modify, merge, publish,
+distribute, sublicense, sell, or otherwise exploit any part of the Software, in
+whole or in part, without the prior written consent of the copyright holder.
+
+Unauthorized reproduction, distribution, or use of the Software, its design, or
+its content is strictly prohibited.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+AUTHOR OR COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Developer Portfolio site ⚡️
 
-<img src="/src/images/favicon.png" alt="Developer Logo" height="128" />
+<img src="public/favicon.png" alt="Developer Logo" height="128" />
 
 ## A clean, beautiful and responsive portfolio
 
@@ -10,17 +10,15 @@ Have a project you'd like to discuss? Let's chat!
 
 ## Technologies used 🛠️
 
-- [Gatsby](https://www.gatsbyjs.org/) - Static Site Generator
-- [GraphQL](https://graphql.org/) - Query language for APIs
-- [React](https://es.reactjs.org/) - Front-End JavaScript library
-- [Bootstrap 4](https://getbootstrap.com/docs/4.3/getting-started/introduction/) - Front-End UI library
-- [Sass](https://sass-lang.com/documentation) - CSS extension language
+- [Astro](https://astro.build/) - Static Site Generator
+- [TypeScript](https://www.typescriptlang.org/) - Typed JavaScript
+- [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS framework
+- [Netlify](https://www.netlify.com/) - Build, deploy & hosting
 
 ## Status
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/8e427aea-c471-4df8-a6b6-45f810117329/deploy-status)](https://app.netlify.com/sites/gallant-jones-cb9d3f/deploys)
-![David](https://img.shields.io/david/dev/glennsyang/glennsheppard.dev) [![HitCount](http://hits.dwyl.com/glennsyang/glennsheppard.dev.svg)](http://hits.dwyl.com/glennsyang/glennsheppard.dev)
 
-## Acknowledgments 🎁
+## License 📄
 
-- **Jacobo Martinez** - [https://github.com/cobidev](https://github.com/cobidev)
+All Rights Reserved © 2026 Glenn Sheppard. This code is provided for viewing only — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Rewrite the README to reflect the current **Astro / TypeScript / Tailwind CSS / Netlify** stack (was outdated Gatsby/React/Bootstrap/Sass)
- Fix the logo path (`public/favicon.png`) and drop dead status badges (David-DM), keeping the Netlify deploy badge
- Remove the Acknowledgments section
- Change the LICENSE from **MIT** to **All Rights Reserved** (proprietary — code is viewable for reference only)
- Add a License section to the README linking to the LICENSE file

## Notes
The repo is public, so the license restricts reuse legally but doesn't prevent copying. Making the repo private is the only technical enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)